### PR TITLE
fix(api): restore initiative and profile endpoints

### DIFF
--- a/frontend/components/initiatives/initiative-detail.test.tsx
+++ b/frontend/components/initiatives/initiative-detail.test.tsx
@@ -88,7 +88,7 @@ describe("InitiativeDetail", () => {
     expect(screen.getByRole("heading", { name: "Test Initiative", level: 1 })).toBeDefined()
     expect(screen.getByText("Improve discharge coordination.")).toBeDefined()
     expect(screen.getByText("2 days ago")).toBeDefined()
-    expect(screen.getAllByRole("link", { name: "Patient Flow Command Center" })).toHaveLength(2)
+    expect(screen.getByRole("link", { name: "Patient Flow Command Center" })).toBeDefined()
   })
 })
 

--- a/frontend/components/initiatives/initiative-detail.test.tsx
+++ b/frontend/components/initiatives/initiative-detail.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi, beforeEach } from "vitest"
 import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import { toggleStarAction } from "@/lib/initiatives/actions"
 import type { InitiativeDetailDto } from "@/lib/initiatives/types"
 import { InitiativeDetail } from "./initiative-detail"
-import { toggleStarAction } from "@/lib/initiatives/actions"
 
 // Mock the actions module
 vi.mock("@/lib/initiatives/actions", () => ({
@@ -64,6 +64,31 @@ describe("InitiativeDetail", () => {
     )
 
     expect(screen.queryByRole("link", { name: "Alice Operator" })).toBeNull()
+  })
+
+  it("renders the complete API detail payload", () => {
+    renderDetail(
+      <InitiativeDetail
+        data={{
+          ...mockData,
+          description: "Improve discharge coordination.",
+          lastModifiedDisplay: "2 days ago",
+          collections: [
+            {
+              id: 40,
+              name: "Patient Flow Command Center",
+              description: "Operational patient-flow reports.",
+              starCount: 2,
+            },
+          ],
+        }}
+      />,
+    )
+
+    expect(screen.getByRole("heading", { name: "Test Initiative", level: 1 })).toBeDefined()
+    expect(screen.getByText("Improve discharge coordination.")).toBeDefined()
+    expect(screen.getByText("2 days ago")).toBeDefined()
+    expect(screen.getAllByRole("link", { name: "Patient Flow Command Center" })).toHaveLength(2)
   })
 })
 

--- a/web.Tests/FunctionTests/Controllers/InitiativesApiController.Tests.cs
+++ b/web.Tests/FunctionTests/Controllers/InitiativesApiController.Tests.cs
@@ -8,6 +8,7 @@ using Atlas_Web.Models;
 using Atlas_Web.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
@@ -137,6 +138,54 @@ public class InitiativesApiControllerTests
         Assert.Equal("High", payload.FinancialImpact.Name);
         Assert.Equal("Critical", payload.StrategicImportance.Name);
         Assert.Equal(2, payload.Collections.Count);
+    }
+
+    [Fact]
+    public async Task GetInitiative_SqlServer_ReturnsFormattedLastModifiedDate()
+    {
+        var connectionString = System.Environment.GetEnvironmentVariable("ATLAS_TEST_SQLSERVER");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return;
+        }
+
+        var connection = new SqlConnectionStringBuilder(connectionString)
+        {
+            InitialCatalog = "AtlasInitiativeApiRegression",
+        };
+        var options = new DbContextOptionsBuilder<Atlas_WebContext>()
+            .UseSqlServer(connection.ConnectionString)
+            .Options;
+
+        await using var context = new Atlas_WebContext(options);
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+        var viewer = new User
+        {
+            Username = "viewer",
+            FullnameCalc = "Viewer Name",
+        };
+        var initiative = new Initiative
+        {
+            Name = "Patient Flow",
+            LastUpdateDate = new System.DateTime(2026, 8, 12),
+        };
+        context.Users.Add(viewer);
+        context.Initiatives.Add(initiative);
+        await context.SaveChangesAsync();
+
+        var service = new InitiativesApiService(
+            context,
+            BuildConfig(),
+            new MemoryCache(new MemoryCacheOptions())
+        );
+        var controller = BuildController(service, BuildPrincipal(viewer.UserId, "viewer"));
+
+        var result = await controller.GetInitiative(initiative.InitiativeId);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<InitiativeDetailDto>(ok.Value);
+        Assert.False(string.IsNullOrWhiteSpace(payload.LastModifiedDisplay));
     }
 
     [Fact]

--- a/web.Tests/FunctionTests/Controllers/ProfileApiController.Tests.cs
+++ b/web.Tests/FunctionTests/Controllers/ProfileApiController.Tests.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Atlas_Web.Controllers.Api;
+using Atlas_Web.Models;
+using Atlas_Web.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace web.Tests.FunctionTests.Controllers;
+
+public class ProfileApiControllerTests
+{
+    [Theory]
+    [InlineData("stars")]
+    [InlineData("subscriptions")]
+    public async Task InvalidRelationshipType_ReturnsBadRequest(string endpoint)
+    {
+        var options = new DbContextOptionsBuilder<Atlas_WebContext>()
+            .UseInMemoryDatabase($"profile-invalid-{endpoint}")
+            .Options;
+        await using var context = new Atlas_WebContext(options);
+        var service = new ProfileApiService(
+            context,
+            new ConfigurationBuilder().AddInMemoryCollection().Build()
+        );
+        var controller = new ProfileApiController(service);
+
+        IActionResult result;
+        if (endpoint == "stars")
+        {
+            result = (await controller.GetStars(1, "user")).Result;
+        }
+        else
+        {
+            result = (await controller.GetSubscriptions(1, "user")).Result;
+        }
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+}

--- a/web.Tests/FunctionTests/Services/ProfileApiService.Tests.cs
+++ b/web.Tests/FunctionTests/Services/ProfileApiService.Tests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading.Tasks;
+using Atlas_Web.Contracts.Api.Profile;
+using Atlas_Web.Models;
+using Atlas_Web.Services;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace web.Tests.FunctionTests.Services;
+
+public class ProfileApiServiceTests
+{
+    [Fact]
+    public async Task Analytics_SqlServer_ReturnsSeededRunData()
+    {
+        var connectionString = System.Environment.GetEnvironmentVariable("ATLAS_TEST_SQLSERVER");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return;
+        }
+
+        var connection = new SqlConnectionStringBuilder(connectionString)
+        {
+            InitialCatalog = "AtlasProfileApiRegression",
+        };
+        var options = new DbContextOptionsBuilder<Atlas_WebContext>()
+            .UseSqlServer(connection.ConnectionString)
+            .Options;
+        await using var context = new Atlas_WebContext(options);
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+
+        var now = DateTime.Now.AddHours(-1);
+        var user = new User { Username = "runner", FullnameCalc = "Run User" };
+        var run = new ReportObjectRunData
+        {
+            RunDataId = "PROFILE-RUN-1",
+            RunUser = user,
+            RunStartTime = now,
+            RunStartTime_Hour = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0),
+            RunStartTime_Day = now.Date,
+            RunStartTime_Month = new DateTime(now.Year, now.Month, 1),
+            RunStartTime_Year = new DateTime(now.Year, 1, 1),
+            RunDurationSeconds = 42,
+            RunStatus = "Success",
+            LastLoadDate = now,
+        };
+        context.ReportObjectRunDatas.Add(run);
+        await context.SaveChangesAsync();
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO dbo.ReportObject
+                (ReportObjectBizKey, SourceServer, SourceDB, SourceTable, Name)
+            VALUES
+                ('PROFILE-REPORT-1', 'TestServer', 'TestDatabase', 'TestTable', 'Patient Flow')
+            """
+        );
+        var report = await context.ReportObjects.SingleAsync(x => x.Name == "Patient Flow");
+        context.ReportObjectRunDataBridges.Add(new ReportObjectRunDataBridge
+        {
+            ReportObject = report,
+            RunData = run,
+            Runs = 3,
+        });
+        await context.SaveChangesAsync();
+
+        var service = new ProfileApiService(
+            context,
+            new ConfigurationBuilder().AddInMemoryCollection().Build()
+        );
+
+        var request = new ProfileQueryRequestDto
+        {
+            Id = user.UserId,
+            Type = "user",
+            StartAt = -86400,
+        };
+
+        var chart = await service.GetChartAsync(request, default);
+        var users = await service.GetUsersAsync(request, default);
+        var reports = await service.GetReportsAsync(request, default);
+        var fails = await service.GetFailsAsync(request, default);
+
+        Assert.Equal(3, chart.Runs);
+        Assert.Equal(1, chart.Users);
+        Assert.Equal(42, chart.RunTime);
+        Assert.Single(chart.History);
+        Assert.Equal("Run User", Assert.Single(users).Key);
+        Assert.Equal("Patient Flow", Assert.Single(reports).Key);
+        Assert.Empty(fails);
+    }
+}

--- a/web/Controllers/Api/ProfileApiController.cs
+++ b/web/Controllers/Api/ProfileApiController.cs
@@ -71,7 +71,14 @@ public class ProfileApiController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        return Ok(await _profileApiService.GetStarsAsync(id, type, cancellationToken));
+        try
+        {
+            return Ok(await _profileApiService.GetStarsAsync(id, type, cancellationToken));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 
     [HttpGet("subscriptions")]
@@ -81,6 +88,13 @@ public class ProfileApiController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        return Ok(await _profileApiService.GetSubscriptionsAsync(id, type, cancellationToken));
+        try
+        {
+            return Ok(await _profileApiService.GetSubscriptionsAsync(id, type, cancellationToken));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 }

--- a/web/Services/Initiatives/InitiativesApiService.cs
+++ b/web/Services/Initiatives/InitiativesApiService.cs
@@ -88,75 +88,87 @@ public sealed class InitiativesApiService : IInitiativesApiService
     {
         var currentUserId = user.GetUserId();
         var canViewUserProfiles = user.HasPermission("View Other User") && IsUserProfileEnabled();
+        var initiative = await _context.Initiatives.AsNoTracking()
+            .AsSplitQuery()
+            .Include(x => x.StarredInitiatives)
+            .Include(x => x.OperationOwner)
+            .Include(x => x.ExecutiveOwner)
+            .Include(x => x.LastUpdateUserNavigation)
+            .Include(x => x.FinancialImpactNavigation)
+            .Include(x => x.StrategicImportanceNavigation)
+            .Include(x => x.Collections)
+            .SingleOrDefaultAsync(x => x.InitiativeId == id, cancellationToken);
 
-        return await _context.Initiatives.AsNoTracking()
-            .Where(x => x.InitiativeId == id)
-            .Select(x => new InitiativeDetailDto
-            {
-                Id = x.InitiativeId,
-                Name = x.Name,
-                Description = x.Description,
-                Hidden = x.Hidden,
-                LastModified = x.LastUpdateDate,
-                LastModifiedDisplay = x.LastUpdatedDateDisplayString,
-                IsStarred = x.StarredInitiatives.Any(y => y.Ownerid == currentUserId),
-                StarCount = x.StarredInitiatives.Count,
-                CanCreateInitiative = user.HasPermission("Create Initiative"),
-                CanEditInitiative = user.HasPermission("Edit Initiative"),
-                CanDeleteInitiative = user.HasPermission("Delete Initiative"),
-                CanViewUserProfiles = canViewUserProfiles,
-                Features = BuildFeatures(),
-                OperationOwner = x.OperationOwner == null
-                    ? null
-                    : new InitiativeUserSummaryDto
-                    {
-                        Id = x.OperationOwner.UserId,
-                        Username = x.OperationOwner.Username,
-                        FullName = x.OperationOwner.FullnameCalc,
-                        Email = x.OperationOwner.Email,
-                    },
-                ExecutiveOwner = x.ExecutiveOwner == null
-                    ? null
-                    : new InitiativeUserSummaryDto
-                    {
-                        Id = x.ExecutiveOwner.UserId,
-                        Username = x.ExecutiveOwner.Username,
-                        FullName = x.ExecutiveOwner.FullnameCalc,
-                        Email = x.ExecutiveOwner.Email,
-                    },
-                LastUpdatedBy = x.LastUpdateUserNavigation == null
-                    ? null
-                    : new InitiativeUserSummaryDto
-                    {
-                        Id = x.LastUpdateUserNavigation.UserId,
-                        Username = x.LastUpdateUserNavigation.Username,
-                        FullName = x.LastUpdateUserNavigation.FullnameCalc,
-                        Email = x.LastUpdateUserNavigation.Email,
-                    },
-                FinancialImpact = x.FinancialImpactNavigation == null
-                    ? null
-                    : new InitiativeLookupValueDto
-                    {
-                        Id = x.FinancialImpactNavigation.Id,
-                        Name = x.FinancialImpactNavigation.Name,
-                    },
-                StrategicImportance = x.StrategicImportanceNavigation == null
-                    ? null
-                    : new InitiativeLookupValueDto
-                    {
-                        Id = x.StrategicImportanceNavigation.Id,
-                        Name = x.StrategicImportanceNavigation.Name,
-                    },
-                Collections = x.Collections.OrderBy(y => y.Name)
-                    .Select(y => new InitiativeLinkedCollectionDto
-                    {
-                        Id = y.CollectionId,
-                        Name = y.Name,
-                        Description = y.Description,
-                    })
-                    .ToList(),
-            })
-            .SingleOrDefaultAsync(cancellationToken);
+        if (initiative == null)
+        {
+            return null;
+        }
+
+        return new InitiativeDetailDto
+        {
+            Id = initiative.InitiativeId,
+            Name = initiative.Name,
+            Description = initiative.Description,
+            Hidden = initiative.Hidden,
+            LastModified = initiative.LastUpdateDate,
+            LastModifiedDisplay = initiative.LastUpdatedDateDisplayString,
+            IsStarred = initiative.StarredInitiatives.Any(y => y.Ownerid == currentUserId),
+            StarCount = initiative.StarredInitiatives.Count,
+            CanCreateInitiative = user.HasPermission("Create Initiative"),
+            CanEditInitiative = user.HasPermission("Edit Initiative"),
+            CanDeleteInitiative = user.HasPermission("Delete Initiative"),
+            CanViewUserProfiles = canViewUserProfiles,
+            Features = BuildFeatures(),
+            OperationOwner = initiative.OperationOwner == null
+                ? null
+                : new InitiativeUserSummaryDto
+                {
+                    Id = initiative.OperationOwner.UserId,
+                    Username = initiative.OperationOwner.Username,
+                    FullName = initiative.OperationOwner.FullnameCalc,
+                    Email = initiative.OperationOwner.Email,
+                },
+            ExecutiveOwner = initiative.ExecutiveOwner == null
+                ? null
+                : new InitiativeUserSummaryDto
+                {
+                    Id = initiative.ExecutiveOwner.UserId,
+                    Username = initiative.ExecutiveOwner.Username,
+                    FullName = initiative.ExecutiveOwner.FullnameCalc,
+                    Email = initiative.ExecutiveOwner.Email,
+                },
+            LastUpdatedBy = initiative.LastUpdateUserNavigation == null
+                ? null
+                : new InitiativeUserSummaryDto
+                {
+                    Id = initiative.LastUpdateUserNavigation.UserId,
+                    Username = initiative.LastUpdateUserNavigation.Username,
+                    FullName = initiative.LastUpdateUserNavigation.FullnameCalc,
+                    Email = initiative.LastUpdateUserNavigation.Email,
+                },
+            FinancialImpact = initiative.FinancialImpactNavigation == null
+                ? null
+                : new InitiativeLookupValueDto
+                {
+                    Id = initiative.FinancialImpactNavigation.Id,
+                    Name = initiative.FinancialImpactNavigation.Name,
+                },
+            StrategicImportance = initiative.StrategicImportanceNavigation == null
+                ? null
+                : new InitiativeLookupValueDto
+                {
+                    Id = initiative.StrategicImportanceNavigation.Id,
+                    Name = initiative.StrategicImportanceNavigation.Name,
+                },
+            Collections = initiative.Collections.OrderBy(y => y.Name)
+                .Select(y => new InitiativeLinkedCollectionDto
+                {
+                    Id = y.CollectionId,
+                    Name = y.Name,
+                    Description = y.Description,
+                })
+                .ToList(),
+        };
     }
 
     public async Task<InitiativeDetailDto> CreateInitiativeAsync(

--- a/web/Services/Profile/ProfileApiService.cs
+++ b/web/Services/Profile/ProfileApiService.cs
@@ -85,7 +85,7 @@ public sealed class ProfileApiService : IProfileApiService
 
     private sealed class ProfileSubqueryResult
     {
-        public IQueryable<ProfileRunRow> Flattened { get; init; }
+        public IQueryable<ProfileRunRow> Filtered { get; init; }
         public IQueryable<IGrouping<DateTime, ProfileRunRow>> Grouped { get; init; }
         public string DateFormat { get; init; }
     }
@@ -106,7 +106,7 @@ public sealed class ProfileApiService : IProfileApiService
     {
         var query = ToQueryOptions(request);
         var subqueryResult = await BuildSubqueriesAsync(query, cancellationToken);
-        var subquery = subqueryResult.Flattened;
+        var subquery = subqueryResult.Filtered;
         var subqueryGroup = subqueryResult.Grouped;
         var dateFormat = subqueryResult.DateFormat;
 
@@ -144,7 +144,7 @@ public sealed class ProfileApiService : IProfileApiService
         CancellationToken cancellationToken
     )
     {
-        var subquery = (await BuildSubqueriesAsync(ToQueryOptions(request), cancellationToken)).Flattened;
+        var subquery = (await BuildSubqueriesAsync(ToQueryOptions(request), cancellationToken)).Filtered;
 
         var total = await subquery.SumAsync(x => x.Runs, cancellationToken);
         return await (
@@ -173,7 +173,7 @@ public sealed class ProfileApiService : IProfileApiService
         CancellationToken cancellationToken
     )
     {
-        var subquery = (await BuildSubqueriesAsync(ToQueryOptions(request), cancellationToken)).Flattened;
+        var subquery = (await BuildSubqueriesAsync(ToQueryOptions(request), cancellationToken)).Filtered;
 
         var total = await subquery.SumAsync(x => x.Runs, cancellationToken);
         return await (
@@ -206,29 +206,36 @@ public sealed class ProfileApiService : IProfileApiService
         CancellationToken cancellationToken
     )
     {
-        var subquery = (await BuildSubqueriesAsync(ToQueryOptions(request), cancellationToken)).Flattened;
+        var subquery = (await BuildSubqueriesAsync(ToQueryOptions(request), cancellationToken)).Filtered;
 
         var total = await subquery.SumAsync(x => x.Runs, cancellationToken);
-        return await (
+        var failures = await (
             from a in subquery
             where a.RunStatus != "Success"
             group a by a.RunStatus into grp
-            select new ProfileBarItemDto
+            select new
             {
-                Key = SplitCamelCaseRegex.Replace(
-                    RsPrefixRegex.Replace(grp.Key, string.Empty),
-                    " $1"
-                ),
+                Status = grp.Key,
                 Count = grp.Sum(x => x.Runs),
-                Percent = total == 0 ? 0 : (double)grp.Sum(x => x.Runs) / total,
-                TitleOne = "Failed Runs",
-                TitleTwo = "Fails",
             }
         )
             .OrderByDescending(x => x.Count)
             .Take(20)
             .AsNoTracking()
             .ToListAsync(cancellationToken);
+
+        return failures.Select(x => new ProfileBarItemDto
+            {
+                Key = SplitCamelCaseRegex.Replace(
+                    RsPrefixRegex.Replace(x.Status, string.Empty),
+                    " $1"
+                ),
+                Count = x.Count,
+                Percent = total == 0 ? 0 : (double)x.Count / total,
+                TitleOne = "Failed Runs",
+                TitleTwo = "Fails",
+            })
+            .ToList();
     }
 
     public async Task<IReadOnlyList<ProfileRunListItemDto>> GetRunListAsync(
@@ -390,12 +397,10 @@ public sealed class ProfileApiService : IProfileApiService
                 DisplayTitle = r.DisplayTitle,
             };
 
-        var (grouped, dateFormat) = BuildDateGrouping(joined, query, start, end);
-
-        var flattened = grouped.SelectMany(x => x);
+        var (filtered, grouped, dateFormat) = BuildDateGrouping(joined, query, start, end);
         return new ProfileSubqueryResult
         {
-            Flattened = flattened,
+            Filtered = filtered,
             Grouped = grouped,
             DateFormat = dateFormat,
         };
@@ -659,6 +664,7 @@ public sealed class ProfileApiService : IProfileApiService
     }
 
     private static (
+        IQueryable<ProfileRunRow> Filtered,
         IQueryable<IGrouping<DateTime, ProfileRunRow>> Grouped,
         string DateFormat
     ) BuildDateGrouping(
@@ -672,25 +678,34 @@ public sealed class ProfileApiService : IProfileApiService
 
         if (range < 172800)
         {
+            var filtered = joined.Where(x =>
+                x.RunStartTime_Hour >= start && x.RunStartTime_Hour <= end
+            );
             return (
-                joined.Where(x => x.RunStartTime_Hour >= start && x.RunStartTime_Hour <= end)
-                    .GroupBy(x => x.RunStartTime_Hour),
+                filtered,
+                filtered.GroupBy(x => x.RunStartTime_Hour),
                 "h tt"
             );
         }
 
         if (range < 31536000)
         {
+            var filtered = joined.Where(x =>
+                x.RunStartTime_Day >= start && x.RunStartTime_Day <= end
+            );
             return (
-                joined.Where(x => x.RunStartTime_Day >= start && x.RunStartTime_Day <= end)
-                    .GroupBy(x => x.RunStartTime_Day),
+                filtered,
+                filtered.GroupBy(x => x.RunStartTime_Day),
                 range < 691200 ? "ddd M/d" : "MMM d"
             );
         }
 
+        var monthly = joined.Where(x =>
+            x.RunStartTime_Month >= start && x.RunStartTime_Month <= end
+        );
         return (
-            joined.Where(x => x.RunStartTime_Month >= start && x.RunStartTime_Month <= end)
-                .GroupBy(x => x.RunStartTime_Month),
+            monthly,
+            monthly.GroupBy(x => x.RunStartTime_Month),
             "MMM yy"
         );
     }


### PR DESCRIPTION
## Summary
- Fix SQL translation failures in initiative detail and profile analytics endpoints.
- Return validation responses for invalid profile relationship requests.
- Add backend SQL Server regression tests and Next.js initiative rendering coverage.

## Test plan
- [x] Run 70 backend function tests.
- [x] Run SQL Server initiative and profile regression tests.
- [x] Build the backend in Release configuration.
- [x] Run Next.js type checking and targeted frontend linting.